### PR TITLE
Pipeline steps modules

### DIFF
--- a/datapackage_pipelines_measure/generator.py
+++ b/datapackage_pipelines_measure/generator.py
@@ -1,14 +1,14 @@
 import os
 import json
+import pkgutil
 
 from datapackage_pipelines.generators import (
     GeneratorBase,
     steps,
-    slugify,
-    SCHEDULE_NONE
+    slugify
 )
 
-from .config import settings
+from . import pipeline_steps
 
 import logging
 log = logging.getLogger(__name__)
@@ -21,6 +21,25 @@ SCHEMA_FILE = os.path.join(
 
 class Generator(GeneratorBase):
 
+    @staticmethod
+    def _get_pipeline_steps() -> dict:
+        '''
+        Discover available pipeline steps under the `pipeline_steps` package.
+
+        Returns a dict of their {label: add_steps} k/v pairs.
+        '''
+        pkgpath = os.path.dirname(pipeline_steps.__file__)
+
+        pipeline_modules = [getattr(pipeline_steps, name) for _, name, _
+                            in pkgutil.iter_modules([pkgpath])]
+
+        available_steps = {}
+        for module in pipeline_modules:
+            if module.label and module.add_steps:
+                available_steps.update({module.label: module.add_steps})
+
+        return available_steps
+
     @classmethod
     def get_schema(cls):
         return json.load(open(SCHEMA_FILE))
@@ -28,59 +47,31 @@ class Generator(GeneratorBase):
     @classmethod
     def generate_pipeline(cls, source):
         metadata_project = slugify(source['project'])
+        schedule = None
+
+        discovered_steps = cls._get_pipeline_steps()
 
         for k, config in source['config'].items():
-            pipeline_id = slugify('{}-{}'.format(source['project'], k))
-            schedule = SCHEDULE_NONE
+            # `k` corresponds with `label` in pipeline_steps module.
+            if k in discovered_steps.keys():
+                pipeline_id = slugify('{}-{}'.format(source['project'], k))
 
-            # Mock pipeline step, to be replaced with real ones later. Likely
-            # broken out into separate modules.
-            if k == 'social-media':
-                pipeline_steps = steps(*[
-                    ('add_metadata', {
-                        'project': metadata_project,
-                        'name': pipeline_id,
-                        'github': settings.GITHUB_API_BASE_URL
-                    }),
-                    ('add_resource', {
-                        'name': 'test_resource',
-                        'url': 'https://docs.google.com/spreadsheets/d/' +
-                        '1vbhTuMDNCmxdo2rPkkya9v6X1f9eyqvSGsY5YcxlcLk/' +
-                        'edit#gid=0'
-                    }),
-                    ('stream_remote_resources', {}),
-                    ('measure.capitalise', {}),
-                    ('dump.to_path', {
-                        'out-path':
-                            '{}/downloads/{}'.format(ROOT_PATH, pipeline_id)
-                    })
-                ])
-            elif k == 'code-hosting':
-                pipeline_steps = steps(*[
+                common_steps = [
                     ('add_metadata', {
                         'project': metadata_project,
                         'name': pipeline_id
-                    }),
-                    ('add_resource', {
-                        'name': 'test_resource',
-                        'url': 'https://docs.google.com/spreadsheets/d/' +
-                        '1vbhTuMDNCmxdo2rPkkya9v6X1f9eyqvSGsY5YcxlcLk/' +
-                        'edit#gid=0'
-                    }),
-                    ('stream_remote_resources', {}),
-                    ('measure.capitalise', {}),
-                    ('dump.to_path', {
-                        'out-path':
-                            '{}/downloads/{}'.format(ROOT_PATH, pipeline_id)
                     })
-                ])
+                ]
+
+                k_steps = discovered_steps[k](common_steps, pipeline_id)
+                _steps = steps(*k_steps)
             else:
                 log.warn('No {} pipeline generator available for {}'.format(
                     k, metadata_project))
                 continue
 
             pipeline_details = {
-                'pipeline': pipeline_steps
+                'pipeline': _steps
             }
             if schedule is not None:
                 pipeline_details['schedule']['crontab'] = schedule

--- a/datapackage_pipelines_measure/pipeline_steps/__init__.py
+++ b/datapackage_pipelines_measure/pipeline_steps/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     social_media,
-    code_hosting
+    code_hosting,
+    example
 )
 
-__all__ = ['social_media', 'code_hosting']
+__all__ = ['social_media', 'code_hosting', 'example']

--- a/datapackage_pipelines_measure/pipeline_steps/__init__.py
+++ b/datapackage_pipelines_measure/pipeline_steps/__init__.py
@@ -1,0 +1,6 @@
+from . import (
+    social_media,
+    code_hosting
+)
+
+__all__ = ['social_media', 'code_hosting']

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -1,0 +1,24 @@
+import os
+
+
+ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
+
+label = 'code-hosting'
+
+
+def add_steps(steps: list, pipeline_id: str) -> list:
+    return steps + [
+        ('add_resource', {
+            'name': 'test_resource',
+            'url': 'https://docs.google.com/spreadsheets/d/' +
+            '1vbhTuMDNCmxdo2rPkkya9v6X1f9eyqvSGsY5YcxlcLk/' +
+            'edit#gid=0'
+        }),
+        ('stream_remote_resources', {}),
+        ('measure.capitalise', {}),
+        ('dump.to_path', {
+            'out-path':
+                '{}/downloads/{}'.format(ROOT_PATH, pipeline_id)
+        })
+    ]

--- a/datapackage_pipelines_measure/pipeline_steps/example.py
+++ b/datapackage_pipelines_measure/pipeline_steps/example.py
@@ -1,0 +1,17 @@
+'''An example pipeline steps module for testing.'''
+
+import os
+
+
+ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
+
+label = 'example'
+
+
+def add_steps(steps: list, pipeline_id: str) -> list:
+    return steps + [
+        ('add_metadata', {
+            'foo': 'bar'
+        })
+    ]

--- a/datapackage_pipelines_measure/pipeline_steps/social_media.py
+++ b/datapackage_pipelines_measure/pipeline_steps/social_media.py
@@ -1,0 +1,27 @@
+import os
+
+from ..config import settings
+
+ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
+label = 'social-media'
+
+
+def add_steps(steps: list, pipeline_id: str) -> list:
+    return steps + [
+        ('add_metadata', {
+            'github': settings.GITHUB_API_BASE_URL
+        }),
+        ('add_resource', {
+            'name': 'test_resource',
+            'url': 'https://docs.google.com/spreadsheets/d/' +
+            '1vbhTuMDNCmxdo2rPkkya9v6X1f9eyqvSGsY5YcxlcLk/' +
+            'edit#gid=0'
+        }),
+        ('stream_remote_resources', {}),
+        ('measure.capitalise', {}),
+        ('dump.to_path', {
+            'out-path':
+                '{}/downloads/{}'.format(ROOT_PATH, pipeline_id)
+        })
+    ]

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -9,10 +9,9 @@ from datapackage_pipelines_measure import Generator
 
 class TestPipelineSteps(unittest.TestCase):
 
-    '''Test that all submodules of the pipeline_steps module contain the
-    expected properties and functions.'''
-
     def test_modules_contain_expected_items(self):
+        '''Test that all submodules of the pipeline_steps module contain the
+        expected properties and functions.'''
         pkgpath = os.path.dirname(pipeline_steps.__file__)
 
         pipeline_modules = [getattr(pipeline_steps, name) for _, name, _
@@ -49,3 +48,21 @@ class TestPipelineSteps(unittest.TestCase):
         # example pipeline adds metadata
         assert {'run': 'add_metadata', 'parameters': {'foo': 'bar'}} \
             in pipeline_details['pipeline']
+
+    def test_pipeline_generator_no_support(self):
+        '''Test the Generator.generate_pipeline logs warning when no steps
+        available to support source type.'''
+        source = {
+            'project': 'my-project',
+            'config': {
+                'not-supported': {}
+            }
+        }
+
+        logger = 'datapackage_pipelines_measure.generator'
+        msg = 'No not-supported pipeline generator available for my-project'
+        with self.assertLogs(logger,
+                             level='WARN') as cm:
+            gen = list(Generator.generate_pipeline(source))
+            self.assertEqual(cm.output, ['WARNING:{}:{}'.format(logger, msg)])
+            assert len(gen) is 0

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -4,6 +4,7 @@ import unittest
 import inspect
 
 from datapackage_pipelines_measure import pipeline_steps
+from datapackage_pipelines_measure import Generator
 
 
 class TestPipelineSteps(unittest.TestCase):
@@ -27,3 +28,24 @@ class TestPipelineSteps(unittest.TestCase):
             sig = inspect.signature(module.add_steps)
             sig_args = [a for a in sig.parameters]
             assert sig_args == ['steps', 'pipeline_id']
+
+    def test_pipeline_generator(self):
+        '''Test the Generator.generate_pipeline method yields as expected for a
+        given source input.'''
+        source = {
+            'project': 'example-project',
+            'config': {
+                'example': {}
+            }
+        }
+
+        gen = list(Generator.generate_pipeline(source))
+        pipeline_id, pipeline_details = gen[0]
+        assert len(gen) is 1
+        # pipeline id
+        assert pipeline_id == 'example-project-example'
+        # pipeline details
+        assert 'pipeline' in pipeline_details.keys()
+        # example pipeline adds metadata
+        assert {'run': 'add_metadata', 'parameters': {'foo': 'bar'}} \
+            in pipeline_details['pipeline']

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -1,0 +1,29 @@
+import os
+import pkgutil
+import unittest
+import inspect
+
+from datapackage_pipelines_measure import pipeline_steps
+
+
+class TestPipelineSteps(unittest.TestCase):
+
+    '''Test that all submodules of the pipeline_steps module contain the
+    expected properties and functions.'''
+
+    def test_modules_contain_expected_items(self):
+        pkgpath = os.path.dirname(pipeline_steps.__file__)
+
+        pipeline_modules = [getattr(pipeline_steps, name) for _, name, _
+                            in pkgutil.iter_modules([pkgpath])]
+
+        for module in pipeline_modules:
+            assert module.label, 'pipeline module must have a label property'
+            assert isinstance(module.label, str), 'label must be a string'
+
+            assert module.add_steps, 'pipeline module must have an ' \
+                'add_steps function'
+            assert callable(module.add_steps), 'add_steps must be callable'
+            sig = inspect.signature(module.add_steps)
+            sig_args = [a for a in sig.parameters]
+            assert sig_args == ['steps', 'pipeline_id']


### PR DESCRIPTION
This PR moves pipeline step logic from the Generator into separate modules. These modules are discovered by the Generator when `generate_pipelines` is run. Each `pipeline_step` module must have:

- `label` property: corresponding with the pipeline type in the source-spec document, e.g. social-media or code-hosting
- `add_steps` function: modifies and returns a passed pipeline processor steps list

A new test exists to enforce this convention.

* [x] I've added tests to cover the proposed changes
