### PR TITLE
Github processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,67 @@ The main change here is having a clean, openly available codebase, and using a m
 
 Potentially, we'd love to see interest from other non-profits who receive funds to execute on projects, and would like a simple yet systematic way to collect data on what they do.
 
+## Project Configuration
+
+Each project has a `measure.source-spec.yaml` configuration file within a project directory in `/projects`, e.g. for the Frictionless Data project:
+
+```
+/projects/
+└── frictionlessdata
+    └── measure.source-spec.yaml
+└── anotherproject
+    └── measure.source-spec.yaml
+```
+
+The YAML file defines the project name, and configuration settings for each data source we want to measure. Data sources are grouped by theme, e.g. `code-hosting`, `social-media`, and `code-packaging`. Under each theme is the specific configuration for each data source. Here is an example of the basic structure for a project configuration file:
+
+```yaml
+# measure.source-spec.yaml
+
+project: frictionlessdata
+
+config:
+  code-hosting: # <------- theme
+    github:  # <---------- data source
+      repositories:  # <-- data source settings
+        - "frictionlessdata/jsontableschema-models-js"
+        - "frictionlessdata/datapackage-pipelines"
+        [...]
+
+  social-media:
+    twitter:
+      entities:
+        - "#frictionlessdata"
+        - "#datapackages"
+        [...]
+```
+
+Below is the specific configuration settings for each type of data source.
+
+### Code hosting
+
+#### Github
+
+The Github processor collects data about each repository listed in the `repositories` section. For each repository, the processor collects:
+
+- the number of **stars**
+- the number of **watchers**
+
+```yaml
+config:
+  code-hosting:
+    github:
+      repositories:
+        - "frictionlessdata/jsontableschema-models-js"
+        - "frictionlessdata/datapackage-pipelines"
+```
+
+
 ## Installation
 
 ### Environmental Variables
+
+Each installation of Measure requires certain environmental variables to be set.
 
 #### General
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ We have demonstrated the value of this data collection as part of the project li
 The main change here is having a clean, openly available codebase, and using a more suitable database and dashboard builder, as well as adding additional collectors.
 
 Potentially, we'd love to see interest from other non-profits who receive funds to execute on projects, and would like a simple yet systematic way to collect data on what they do.
+
+## Installation
+
+### Environmental Variables
+
+#### General
+
+- `MEASURE_DB_ENGINE`: Location of SQL database as a URL Schema
+- `MEASURE_TIMESTAMP_DEFAULT_FORMAT`: datetime format used for `timestamp` value. Currently must be `%Y-%m-%dT%H:%M:%SZ`.
+
+#### Github
+
+- `MEASURE_GITHUB_API_BASE_URL`: Github api base url (`https://api.github.com/repos/`)
+- `MEASURE_GITHUB_API_TOKEN`: Github api token used for making requests

--- a/datapackage_pipelines_measure/generator.py
+++ b/datapackage_pipelines_measure/generator.py
@@ -63,7 +63,9 @@ class Generator(GeneratorBase):
                     })
                 ]
 
-                k_steps = discovered_steps[k](common_steps, pipeline_id)
+                k_steps = discovered_steps[k](common_steps,
+                                              pipeline_id,
+                                              config)
                 _steps = steps(*k_steps)
             else:
                 log.warn('No {} pipeline generator available for {}'.format(

--- a/datapackage_pipelines_measure/generator.py
+++ b/datapackage_pipelines_measure/generator.py
@@ -46,7 +46,7 @@ class Generator(GeneratorBase):
 
     @classmethod
     def generate_pipeline(cls, source):
-        metadata_project = slugify(source['project'])
+        project_id = slugify(source['project'])
         schedule = None
 
         discovered_steps = cls._get_pipeline_steps()
@@ -54,22 +54,23 @@ class Generator(GeneratorBase):
         for k, config in source['config'].items():
             # `k` corresponds with `label` in pipeline_steps module.
             if k in discovered_steps.keys():
-                pipeline_id = slugify('{}-{}'.format(source['project'], k))
+                pipeline_id = slugify('{}-{}'.format(project_id, k))
 
                 common_steps = [
                     ('add_metadata', {
-                        'project': metadata_project,
+                        'project': project_id,
                         'name': pipeline_id
                     })
                 ]
 
                 k_steps = discovered_steps[k](common_steps,
                                               pipeline_id,
+                                              project_id,
                                               config)
                 _steps = steps(*k_steps)
             else:
                 log.warn('No {} pipeline generator available for {}'.format(
-                    k, metadata_project))
+                    k, project_id))
                 continue
 
             pipeline_details = {

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -9,7 +9,8 @@ DOWNLOADS_PATH = os.path.join(os.path.dirname(__file__), '../../downloads')
 label = 'code-hosting'
 
 
-def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
+def add_steps(steps: list, pipeline_id: str,
+              project_id: str, config: dict) -> list:
     for repo in config['github']['repositories']:
         steps.append(('measure.add_github_resource', {
             'name': slugify(repo),
@@ -47,6 +48,7 @@ def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
         }
     }))
 
+    steps.append(('measure.add_project_name', {'name': project_id}))
     steps.append(('measure.add_timestamp'))
     steps.append(('measure.add_uuid'))
 

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -52,4 +52,13 @@ def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
         'out-path': '{}/{}'.format(DOWNLOADS_PATH, pipeline_id)
     }))
 
+    steps.append(('dump.to_sql', {
+        'engine': settings.DB_ENGINE,
+        'tables': {
+            'codehosting': {
+                'resource-name': 'code-hosting'
+            }
+        }
+    }))
+
     return steps

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -48,6 +48,7 @@ def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
     }))
 
     steps.append(('measure.add_timestamp'))
+    steps.append(('measure.add_uuid'))
 
     # temporarily dump to path for development
     steps.append(('dump.to_path', {

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -61,7 +61,8 @@ def add_steps(steps: list, pipeline_id: str,
         'engine': settings.DB_ENGINE,
         'tables': {
             'codehosting': {
-                'resource-name': 'code-hosting'
+                'resource-name': 'code-hosting',
+                'mode': 'append'
             }
         }
     }))

--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -47,6 +47,8 @@ def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
         }
     }))
 
+    steps.append(('measure.add_timestamp'))
+
     # temporarily dump to path for development
     steps.append(('dump.to_path', {
         'out-path': '{}/{}'.format(DOWNLOADS_PATH, pipeline_id)

--- a/datapackage_pipelines_measure/pipeline_steps/example.py
+++ b/datapackage_pipelines_measure/pipeline_steps/example.py
@@ -9,7 +9,8 @@ ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 label = 'example'
 
 
-def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
+def add_steps(steps: list, pipeline_id: str,
+              project_id: str, config: dict) -> list:
     return steps + [
         ('add_metadata', {
             'foo': 'bar'

--- a/datapackage_pipelines_measure/pipeline_steps/example.py
+++ b/datapackage_pipelines_measure/pipeline_steps/example.py
@@ -9,7 +9,7 @@ ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 label = 'example'
 
 
-def add_steps(steps: list, pipeline_id: str) -> list:
+def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
     return steps + [
         ('add_metadata', {
             'foo': 'bar'

--- a/datapackage_pipelines_measure/pipeline_steps/social_media.py
+++ b/datapackage_pipelines_measure/pipeline_steps/social_media.py
@@ -1,17 +1,12 @@
 import os
 
-from ..config import settings
-
 ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 
 label = 'social-media'
 
 
-def add_steps(steps: list, pipeline_id: str) -> list:
+def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
     return steps + [
-        ('add_metadata', {
-            'github': settings.GITHUB_API_BASE_URL
-        }),
         ('add_resource', {
             'name': 'test_resource',
             'url': 'https://docs.google.com/spreadsheets/d/' +

--- a/datapackage_pipelines_measure/pipeline_steps/social_media.py
+++ b/datapackage_pipelines_measure/pipeline_steps/social_media.py
@@ -5,7 +5,8 @@ ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 label = 'social-media'
 
 
-def add_steps(steps: list, pipeline_id: str, config: dict) -> list:
+def add_steps(steps: list, pipeline_id: str,
+              project_id: str, config: dict) -> list:
     return steps + [
         ('add_resource', {
             'name': 'test_resource',

--- a/datapackage_pipelines_measure/processors/add_github_resource.py
+++ b/datapackage_pipelines_measure/processors/add_github_resource.py
@@ -1,0 +1,52 @@
+import collections
+import tempfile
+import json
+import itertools
+
+import requests
+import tabulator
+from datapackage_pipelines.wrapper import ingest, spew
+
+from datapackage_pipelines_measure.config import settings
+
+import logging
+log = logging.getLogger(__name__)
+
+parameters, datapackage, res_iter = ingest()
+
+name = str(parameters['name'])
+repo = parameters.get('repo')
+repo_url = '{}{}?access_token={}'.format(settings.GITHUB_API_BASE_URL,
+                                         repo,
+                                         settings.GITHUB_API_TOKEN)
+
+# What if not json response?
+repo_content = requests.get(repo_url).json()
+
+# remap retrieved dict to scheme in parameters
+resource_content = {t_key: repo_content[s_key]
+                    for t_key, s_key in parameters['map_fields'].items()}
+
+resource_content = collections.OrderedDict(sorted(resource_content.items(),
+                                                  key=lambda t: t[0]))
+
+resource = {
+    'name': name,
+    'path': 'data/{}.json'.format(name)
+}
+
+with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as out:
+    out.write(bytes(json.dumps([resource_content]), encoding='utf-8'))
+
+headers = list(resource_content.keys())
+
+with tabulator.Stream('file://'+out.name,
+                      format='json', headers=headers) as stream:
+    # temporarily set all types to string, will use `set_types` processor in
+    # pipeline to assign correct types
+    resource['schema'] = {
+        'fields': [{'name': h, 'type': 'string'} for h in stream.headers]}
+
+datapackage['resources'].append(resource)
+
+spew(datapackage, itertools.chain(res_iter, [stream.iter(keyed=True)]))

--- a/datapackage_pipelines_measure/processors/add_github_resource.py
+++ b/datapackage_pipelines_measure/processors/add_github_resource.py
@@ -20,8 +20,11 @@ repo_url = '{}{}?access_token={}'.format(settings.GITHUB_API_BASE_URL,
                                          repo,
                                          settings.GITHUB_API_TOKEN)
 
-# What if not json response?
-repo_content = requests.get(repo_url).json()
+try:
+    repo_content = requests.get(repo_url).json()
+except json.decoder.JSONDecodeError:
+    log.error('Expected JSON in response from: {}'.format(repo_url))
+    raise
 
 # remap retrieved dict to scheme in parameters
 resource_content = {t_key: repo_content[s_key]

--- a/datapackage_pipelines_measure/processors/add_project_name.py
+++ b/datapackage_pipelines_measure/processors/add_project_name.py
@@ -1,0 +1,25 @@
+from datapackage_pipelines.wrapper import process
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def modify_datapackage(datapackage, parameters, stats):
+    datapackage['resources'][0]['schema']['fields'].append({
+      'name': 'project_id',
+      'type': 'string',
+      'constraints': {
+        'required': True
+      }
+    })
+    return datapackage
+
+
+def process_row(row, row_index,
+                resource_descriptor, resource_index,
+                parameters, stats):
+    row['project_id'] = parameters['name']
+    return row
+
+
+process(modify_datapackage=modify_datapackage, process_row=process_row)

--- a/datapackage_pipelines_measure/processors/add_timestamp.py
+++ b/datapackage_pipelines_measure/processors/add_timestamp.py
@@ -4,9 +4,6 @@ from datapackage_pipelines.wrapper import process
 
 from datapackage_pipelines_measure.config import settings
 
-import logging
-log = logging.getLogger(__name__)
-
 
 NOW = datetime.datetime.now().strftime(settings.TIMESTAMP_DEFAULT_FORMAT)
 

--- a/datapackage_pipelines_measure/processors/add_timestamp.py
+++ b/datapackage_pipelines_measure/processors/add_timestamp.py
@@ -11,7 +11,8 @@ log = logging.getLogger(__name__)
 def modify_datapackage(datapackage, parameters, stats):
     datapackage['resources'][0]['schema']['fields'].append({
       'name': 'timestamp',
-      'type': 'string'
+      'type': 'datetime',
+      'format': '{}'.format(settings.TIMESTAMP_DEFAULT_FORMAT)
     })
     return datapackage
 

--- a/datapackage_pipelines_measure/processors/add_timestamp.py
+++ b/datapackage_pipelines_measure/processors/add_timestamp.py
@@ -8,6 +8,9 @@ import logging
 log = logging.getLogger(__name__)
 
 
+NOW = datetime.datetime.now().strftime(settings.TIMESTAMP_DEFAULT_FORMAT)
+
+
 def modify_datapackage(datapackage, parameters, stats):
     datapackage['resources'][0]['schema']['fields'].append({
       'name': 'timestamp',
@@ -18,8 +21,7 @@ def modify_datapackage(datapackage, parameters, stats):
 
 
 def process_row(row, *args):
-    now = datetime.datetime.now().strftime(settings.TIMESTAMP_DEFAULT_FORMAT)
-    row['timestamp'] = now
+    row['timestamp'] = NOW
     return row
 
 

--- a/datapackage_pipelines_measure/processors/add_timestamp.py
+++ b/datapackage_pipelines_measure/processors/add_timestamp.py
@@ -1,0 +1,25 @@
+import datetime
+
+from datapackage_pipelines.wrapper import process
+
+from datapackage_pipelines_measure.config import settings
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def modify_datapackage(datapackage, parameters, stats):
+    datapackage['resources'][0]['schema']['fields'].append({
+      'name': 'timestamp',
+      'type': 'string'
+    })
+    return datapackage
+
+
+def process_row(row, *args):
+    now = datetime.datetime.now().strftime(settings.TIMESTAMP_DEFAULT_FORMAT)
+    row['timestamp'] = now
+    return row
+
+
+process(modify_datapackage=modify_datapackage, process_row=process_row)

--- a/datapackage_pipelines_measure/processors/add_uuid.py
+++ b/datapackage_pipelines_measure/processors/add_uuid.py
@@ -1,0 +1,27 @@
+import uuid
+
+from datapackage_pipelines.wrapper import process
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def modify_datapackage(datapackage, parameters, stats):
+    datapackage['resources'][0]['schema']['fields'].append({
+      'name': 'id',
+      'type': 'string',
+      'format': 'uuid',
+      'constraints': {
+        'required': True,
+        'unique': True
+      }
+    })
+    return datapackage
+
+
+def process_row(row, *args):
+    row['id'] = str(uuid.uuid4())
+    return row
+
+
+process(modify_datapackage=modify_datapackage, process_row=process_row)

--- a/datapackage_pipelines_measure/processors/add_uuid.py
+++ b/datapackage_pipelines_measure/processors/add_uuid.py
@@ -16,6 +16,7 @@ def modify_datapackage(datapackage, parameters, stats):
         'unique': True
       }
     })
+    datapackage['resources'][0]['schema']['primaryKey'] = 'id'
     return datapackage
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ def read(*paths):
 PACKAGE = 'datapackage_pipelines_measure'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
-    'datapackage-pipelines'
+    'datapackage-pipelines',
+    'psycopg2'
 ]
 TESTS_REQUIRE = [
     'pylama',

--- a/tests/fixtures/simple_add_project_name
+++ b/tests/fixtures/simple_add_project_name
@@ -1,0 +1,49 @@
+add_project_name
+--
+{
+    "name": "my-project"
+}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "hello-world",
+            "path": "hi.csv",
+            "schema": { "fields": [
+                {"name": "hello", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"hello": "world"}
+--
+{
+  "name": "test",
+  "resources": [
+    {
+      "name": "hello-world",
+      "path": "hi.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "hello",
+            "type": "string"
+          },
+          {
+            "constraints": {
+              "required": true
+            },
+            "name": "project_id",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}
+--
+{"hello": "world", "project_id": "my-project"}
+
+{}

--- a/tests/fixtures_timestamp/simple_add_timestamp
+++ b/tests/fixtures_timestamp/simple_add_timestamp
@@ -30,8 +30,9 @@ add_timestamp
             "type": "string"
           },
           {
+            "format": "%Y-%m-%dT%H:%M:%SZ",
             "name": "timestamp",
-            "type": "string"
+            "type": "datetime"
           }
         ]
       }

--- a/tests/fixtures_timestamp/simple_add_timestamp
+++ b/tests/fixtures_timestamp/simple_add_timestamp
@@ -1,0 +1,44 @@
+add_timestamp
+--
+{}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "hello-world",
+            "path": "hi.csv",
+            "schema": { "fields": [
+                {"name": "hello", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"hello": "world"}
+--
+{
+  "name": "test",
+  "resources": [
+    {
+      "name": "hello-world",
+      "path": "hi.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "hello",
+            "type": "string"
+          },
+          {
+            "name": "timestamp",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}
+--
+{"hello": "World"}
+
+{}

--- a/tests/fixtures_timestamp/simple_add_timestamp
+++ b/tests/fixtures_timestamp/simple_add_timestamp
@@ -40,6 +40,4 @@ add_timestamp
   ]
 }
 --
-{"hello": "World"}
-
-{}
+# expected output tested in test method

--- a/tests/fixtures_uuid/simple_add_uuid
+++ b/tests/fixtures_uuid/simple_add_uuid
@@ -1,0 +1,50 @@
+add_uuid
+--
+{}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "hello-world",
+            "path": "hi.csv",
+            "schema": { "fields": [
+                {"name": "hello", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"hello": "world"}
+--
+{
+  "name": "test",
+  "resources": [
+    {
+      "name": "hello-world",
+      "path": "hi.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "hello",
+            "type": "string"
+          },
+          {
+            "constraints": {
+              "required": true,
+              "unique": true
+            },
+            "format": "uuid",
+            "name": "id",
+            "type": "string"
+          }
+        ],
+        "primaryKey": "id"
+      }
+    }
+  ]
+}
+--
+{"hello": "World"}
+
+{}

--- a/tests/fixtures_uuid/simple_add_uuid
+++ b/tests/fixtures_uuid/simple_add_uuid
@@ -45,6 +45,4 @@ add_uuid
   ]
 }
 --
-{"hello": "World"}
-
-{}
+# expected output tested in test method

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -26,7 +26,7 @@ class TestPipelineSteps(unittest.TestCase):
             assert callable(module.add_steps), 'add_steps must be callable'
             sig = inspect.signature(module.add_steps)
             sig_args = [a for a in sig.parameters]
-            assert sig_args == ['steps', 'pipeline_id', 'config']
+            assert sig_args == ['steps', 'pipeline_id', 'project_id', 'config']
 
 
 class TestPipelineGenerator(unittest.TestCase):

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -26,7 +26,10 @@ class TestPipelineSteps(unittest.TestCase):
             assert callable(module.add_steps), 'add_steps must be callable'
             sig = inspect.signature(module.add_steps)
             sig_args = [a for a in sig.parameters]
-            assert sig_args == ['steps', 'pipeline_id']
+            assert sig_args == ['steps', 'pipeline_id', 'config']
+
+
+class TestPipelineGenerator(unittest.TestCase):
 
     def test_pipeline_generator(self):
         '''Test the Generator.generate_pipeline method yields as expected for a

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
+import sys
+import json
+import datetime
+import subprocess
 
 from datapackage_pipelines.utilities.lib_test_helpers import (
-    ProcessorFixtureTestsBase
+    ProcessorFixtureTestsBase,
+    rejsonize
 )
+
+import logging
+log = logging.getLogger(__name__)
 
 ROOT_PATH = os.path.join(os.path.dirname(__file__), '..')
 ENV = os.environ.copy()
@@ -23,8 +32,68 @@ class MeasureProcessorsFixturesTest(ProcessorFixtureTestsBase):
                             'processors',
                             processor.strip() + '.py')
 
+    @staticmethod
+    def _get_first_data(processor, parameters, data_in,
+                        dp_out, data_out, env):
+        '''Returns the first line of data_out as a python object.'''
+        process = subprocess.run([sys.executable, processor, '1',
+                                  parameters, 'False', ''],
+                                 input=data_in,
+                                 stdout=subprocess.PIPE,
+                                 env=env)
+        output = process.stdout.decode('utf8')
+        (actual_dp, *actual_data) = output.split('\n\n', 1)
+        assert actual_dp == dp_out, \
+            "unexpected value for output datapackage: {}".format(actual_dp)
+        if len(actual_data) > 0:
+            actual_data = actual_data[0]
+            actual_data = actual_data.split('\n')
+            actual = actual_data[0]
+            rj_actual = rejsonize(actual)
+            return json.loads(rj_actual)
+
 
 for filename, testfunc in MeasureProcessorsFixturesTest(
                             os.path.join(os.path.dirname(__file__), 'fixtures')
                             ).get_tests():
+    globals()['test_processors_%s' % filename] = testfunc
+
+
+class MeasureProcessorsFixturesTest_UUID(MeasureProcessorsFixturesTest):
+
+    @staticmethod
+    def test_single_fixture(*args):
+        """Test `id` is in output data."""
+        actual_json = MeasureProcessorsFixturesTest_UUID._get_first_data(*args)
+        assert 'id' in actual_json
+        uuid_regexp = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}") # noqa
+        assert uuid_regexp.match(actual_json['id']), \
+            "id must match uuid regexp"
+
+
+for filename, testfunc in MeasureProcessorsFixturesTest_UUID(
+                    os.path.join(os.path.dirname(__file__), 'fixtures_uuid')
+                    ).get_tests():
+    globals()['test_processors_%s' % filename] = testfunc
+
+
+class MeasureProcessorsFixturesTest_Timestamp(MeasureProcessorsFixturesTest):
+
+    @staticmethod
+    def test_single_fixture(*args):
+        """Test `timestamp` is in the output data."""
+        actual_json = \
+            MeasureProcessorsFixturesTest_Timestamp._get_first_data(*args)
+        assert 'timestamp' in actual_json
+        try:
+            datetime.datetime.strptime(actual_json['timestamp'],
+                                       '%d-%m-%Y %H:%M:%S')
+        except ValueError:
+            assert False, \
+                "Timestamp must be a datetime in the correct format"
+
+
+for filename, testfunc in MeasureProcessorsFixturesTest_Timestamp(
+                    os.path.join(os.path.dirname(__file__),
+                                 'fixtures_timestamp')).get_tests():
     globals()['test_processors_%s' % filename] = testfunc

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -87,7 +87,7 @@ class MeasureProcessorsFixturesTest_Timestamp(MeasureProcessorsFixturesTest):
         assert 'timestamp' in actual_json
         try:
             datetime.datetime.strptime(actual_json['timestamp'],
-                                       '%d-%m-%Y %H:%M:%S')
+                                       '%Y-%m-%dT%H:%M:%SZ')
         except ValueError:
             assert False, \
                 "Timestamp must be a datetime in the correct format"

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ passenv=
   TRAVIS
   TRAVIS_JOB_ID
   TRAVIS_BRANCH
+setenv=
+  MEASURE_TIMESTAMP_DEFAULT_FORMAT=%Y-%m-%dT%H:%M:%SZ
 commands=
   py.test \
     --cov {[tox]package} \


### PR DESCRIPTION
This pull request fixes #14. Note: tests in this PR require frictionlessdata/datapackage-pipelines#42 to be merged.

This is the first processor for the new Measure app.

- `add_github_resource` processor that requests github repo details, and adds specified keys as new rows.
- Some common shared processors:
  - `add_uuid` adds a uuid to be used as a unique id for the row
  - `add_timestamp` adds a timestamp when the data was collected
  - `add_project_name` adds the project name to each row

These processors are used in a `code-hosting` pipeline and rows are appended to a `codehosting` table in an sql db. The sql db is defined by the `MEASURE_DB_ENGINE` env var. 