### PR TITLE
Add `date` column to codehosting pipelines

### DIFF
--- a/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_hosting.py
@@ -32,7 +32,8 @@ def add_steps(steps: list, pipeline_id: str,
             'repository': [],
             'watchers': [],
             'stars': [],
-            'source': []}
+            'source': [],
+            'date': []}
     }))
 
     steps.append(('set_types', {
@@ -45,7 +46,10 @@ def add_steps(steps: list, pipeline_id: str,
             },
             'stars': {
                 'type': 'integer'
-            }
+            },
+            'date': {
+                'type': 'date',
+            },
         }
     }))
 
@@ -64,7 +68,8 @@ def add_steps(steps: list, pipeline_id: str,
         'tables': {
             'codehosting': {
                 'resource-name': 'code-hosting',
-                'mode': 'append'
+                'mode': 'update',
+                'update_keys': ['repository', 'source', 'project_id', 'date']
             }
         }
     }))

--- a/datapackage_pipelines_measure/processors/add_github_resource.py
+++ b/datapackage_pipelines_measure/processors/add_github_resource.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 import itertools
 
 import requests
@@ -28,6 +29,7 @@ resource_content = []
 row = {t_key: repo_content[s_key]
        for t_key, s_key in parameters['map_fields'].items()}
 row['source'] = 'github'
+row['date'] = datetime.date.today()
 
 resource = {
     'name': name,

--- a/datapackage_pipelines_measure/processors/add_github_resource.py
+++ b/datapackage_pipelines_measure/processors/add_github_resource.py
@@ -23,10 +23,11 @@ except json.decoder.JSONDecodeError:
     log.error('Expected JSON in response from: {}'.format(repo_url))
     raise
 
+resource_content = []
 # remap retrieved dict to scheme in parameters
-resource_content = {t_key: repo_content[s_key]
-                    for t_key, s_key in parameters['map_fields'].items()}
-resource_content['source'] = 'github'
+row = {t_key: repo_content[s_key]
+       for t_key, s_key in parameters['map_fields'].items()}
+row['source'] = 'github'
 
 resource = {
     'name': name,
@@ -36,11 +37,10 @@ resource = {
 # Temporarily set all types to string, will use `set_types` processor in
 # pipeline to assign correct types
 resource['schema'] = {
-    'fields': [{'name': h, 'type': 'string'} for h in resource_content.keys()]}
+    'fields': [{'name': h, 'type': 'string'} for h in row.keys()]}
 
 datapackage['resources'].append(resource)
 
-# Make a single-item generator from the resource_content
-resource_content = itertools.chain([resource_content])
+resource_content.append(row)
 
 spew(datapackage, itertools.chain(res_iter, [resource_content]))

--- a/tests/test_github_processor.py
+++ b/tests/test_github_processor.py
@@ -70,7 +70,8 @@ class TestMeasureGithubProcessor(unittest.TestCase):
         assert dp_resources[0]['name'] == 'hello'
         field_names = \
             [field['name'] for field in dp_resources[0]['schema']['fields']]
-        assert field_names == ['repository', 'watchers', 'stars', 'source']
+        assert field_names == ['repository', 'watchers',
+                               'stars', 'source', 'date']
 
         # Asserts for the res_iter
         spew_res_iter_contents = list(spew_res_iter)
@@ -80,7 +81,8 @@ class TestMeasureGithubProcessor(unittest.TestCase):
                 'repository': 'my-repository',
                 'watchers': 4,
                 'stars': 1,
-                'source': 'github'
+                'source': 'github',
+                'date': datetime.date.today()
             }]
 
 


### PR DESCRIPTION
This pull request fixes #26.

* [x] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- adds `date` to github processor 
- updates codehosting results based on unique properties, including date (so only one row should exist for each date, regardless of how many times the pipeline is run.