### PR TITLE
Google Analytics processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,31 +214,66 @@ Each page listed in the project config file will require a Facebook Page Access 
     - Each page must have its own env var to store its token. e.g. for the OKFNetwork page:
     `MEASURE_FACEBOOK_API_ACCESS_TOKEN_OKFNETWORK='{the OKFNetwork page token obtained above}'`
 
-## Installation
+### Website Analytics
 
-### Environmental Variables
+#### Google Analytics
+
+The Google Analytics processor collects visitor data for specified domain. For each domain the following is collected:
+
+- **visitors**: The total number of visits to the domain each day. In GA terms, this is the number of sessions.
+- **unique_visitors**: The total number of unique visitors who made at least one visit to the domain that day. In GA terms, this is the number of users.
+- **avg_time_spent**: The average session duration in seconds. In GA terms, this is Avg. Session Duration.
+
+Domains are specified in the project configuration and require the domain `url` and Google Analytics `viewid`.
+
+```yaml
+config:
+  website-analytics:
+    ga:
+      domains:
+        - url: 'frictionlessdata.io'
+          viewid: '120195554'
+        - url: 'specs.frictionlessdata.io'
+          viewid: '57520245'
+```
+
+Each `viewid` can be found within your Google Analytics account. See [this short video for guidance](https://www.youtube.com/watch?v=x1MljgyLeRM).
+
+##### Google Analytics Configuration
+
+The Google Analytics processor requires a Google API account with the **Google Analytics Reporting API** enabled.
+
+1. Enable Google Analytics Reporting API:
+    - Go to your [Google Cloud Platform Console](https://console.cloud.google.com/)
+    - Pick the project you are using
+    - Go to **API Manager/Dashboard**
+    - Click on **Enable API**, search for **Google Analytics Reporting API**, click **ENABLE**
+1. Give Measure credentials to the websites' analytics you'd like to track:
+    - Add the service account email to the list of users that has read permissions in the given analytics' accounts
+
+## Environmental Variables
 
 Each installation of Measure requires certain environmental variables to be set.
 
-#### General
+### General
 
 - `MEASURE_DB_ENGINE`: Location of SQL database as a URL Schema
 - `MEASURE_TIMESTAMP_DEFAULT_FORMAT`: datetime format used for `timestamp` value. Currently must be `%Y-%m-%dT%H:%M:%SZ`.
 
-#### Github
+### Github
 
 - `MEASURE_GITHUB_API_BASE_URL`: Github API base url (`https://api.github.com/repos/`)
 - `MEASURE_GITHUB_API_TOKEN`: Github API token used for making requests
 
-#### Twitter
+### Twitter
 
 - `MEASURE_TWITTER_API_CONSUMER_KEY`: Twitter app API consumer key
 - `MEASURE_TWITTER_API_CONSUMER_SECRET`: Twitter app API consumer secret
 
-#### Facebook
+### Facebook
 - `MEASURE_FACEBOOK_API_ACCESS_TOKEN_{PAGE NAME IN UPPERCASE}`: The page access token obtained from [How to get a Facebook Page Access Token](#how-to-get-a-facebook-page-access-token).
 
-#### PyPI
+### PyPI & Google analytics
 See the [PyPI Big Query API](#pypi-configuration) instructions above to get the values for these env vars:
 - `MEASURE_GOOGLE_API_PROJECT_ID`: {project_id}
 - `MEASURE_GOOGLE_API_JWT_AUTH_PROVIDER_X509_CERT_URL`: {auth_provider_x509_cert_url}

--- a/datapackage_pipelines_measure/pipeline_steps/__init__.py
+++ b/datapackage_pipelines_measure/pipeline_steps/__init__.py
@@ -2,7 +2,9 @@ from . import (
     social_media,
     code_hosting,
     code_packaging,
+    website_analytics,
     example
 )
 
-__all__ = ['social_media', 'code_hosting', 'code_packaging', 'example']
+__all__ = ['social_media', 'code_hosting', 'code_packaging',
+           'website_analytics', 'example']

--- a/datapackage_pipelines_measure/pipeline_steps/website_analytics.py
+++ b/datapackage_pipelines_measure/pipeline_steps/website_analytics.py
@@ -1,0 +1,84 @@
+import os
+
+from datapackage_pipelines_measure.config import settings
+
+DOWNLOADS_PATH = os.path.join(os.path.dirname(__file__), '../../downloads')
+
+label = 'website-analytics'
+
+
+def add_steps(steps: list, pipeline_id: str,
+              project_id: str, config: dict) -> list:
+
+    steps.append(('measure.datastore_get_latest', {
+        'resource-name': 'latest-project-entries',
+        'table': 'websiteanalytics',
+        'engine': settings.get('DB_ENGINE'),
+        'distinct_on': ['project_id', 'domain', 'source']
+    }))
+
+    if 'ga' in config:
+        for domain in config['ga']['domains']:
+            steps.append(('measure.add_ga_resource', {
+                'domain': domain
+            }))
+
+    steps.append(('measure.remove_resource', {
+        'name': 'latest-project-entries'
+    }))
+
+    steps.append(('concatenate', {
+        'target': {
+            'name': 'website-analytics',
+            'path': 'data/website-analytics.json'},
+        'fields': {
+            'domain': [],
+            'visitors': [],
+            'unique_visitors': [],
+            'avg_time_spent': [],
+            'source': [],
+            'date': []}
+    }))
+
+    steps.append(('set_types', {
+        'types': {
+            'domain': {
+                'type': 'string',
+            },
+            'visitors': {
+                'type': 'integer'
+            },
+            'unique_visitors': {
+                'type': 'integer'
+            },
+            'avg_time_spent': {
+                'type': 'number'
+            },
+            'date': {
+                'type': 'date',
+            },
+        }
+    }))
+
+    steps.append(('measure.add_project_name', {'name': project_id}))
+    steps.append(('measure.add_timestamp'))
+    steps.append(('measure.add_uuid'))
+
+    # Dump to path if in development mode
+    if settings.get('DEVELOPMENT', False):
+        steps.append(('dump.to_path', {
+            'out-path': '{}/{}'.format(DOWNLOADS_PATH, pipeline_id)
+        }))
+
+    steps.append(('dump.to_sql', {
+        'engine': settings['DB_ENGINE'],
+        'tables': {
+            'websiteanalytics': {
+                'resource-name': 'website-analytics',
+                'mode': 'update',
+                'update_keys': ['domain', 'source', 'project_id', 'date']
+            }
+        }
+    }))
+
+    return steps

--- a/datapackage_pipelines_measure/processors/add_ga_resource.py
+++ b/datapackage_pipelines_measure/processors/add_ga_resource.py
@@ -1,0 +1,153 @@
+import datetime
+import dateutil
+
+from datapackage_pipelines.generators import slugify
+from datapackage_pipelines.wrapper import ingest, spew
+
+from datapackage_pipelines_measure.processors import google_utils
+
+import logging
+log = logging.getLogger(__name__)
+
+GOOGLE_API_GA_TABLE_DATE_RANGE_FORMAT = '%Y-%m-%d'
+GOOGLE_API_GA_TABLE_DEFAULT_FROM_DATE = '2005-01-01'
+
+
+def _request_data_from_ga(domain, view_id, start_date, end_date):
+    '''Build a google analytics api service, then build a query and execute it.
+    Return the results unless there's a error.
+    '''
+    def _build_ga_query(view_id, start_date, end_date):
+        start_date = start_date.strftime(GOOGLE_API_GA_TABLE_DATE_RANGE_FORMAT)
+        end_date = end_date.strftime(GOOGLE_API_GA_TABLE_DATE_RANGE_FORMAT)
+        query = {
+            "reportRequests": [
+                {
+                    "viewId": view_id,
+                    "dateRanges": [
+                        {
+                            "startDate": start_date,
+                            "endDate": end_date
+                        }
+                    ],
+                    "dimensions": [
+                        {
+                            "name": "ga:date"
+                        }
+                    ],
+                    "metrics": [
+                        {
+                            "expression": "ga:sessions"
+                        },
+                        {
+                            "expression": "ga:users"
+                        },
+                        {
+                            "expression": "ga:avgSessionDuration"
+                        }
+                    ],
+                    "pageSize": "10000"
+                }
+            ]
+        }
+        return query
+
+    service = google_utils.get_google_api_service(
+        google_utils.GOOGLE_API_GA_SERVICE_NAME,
+        google_utils.GOOGLE_API_GA_VERSION,
+        google_utils.GOOGLE_API_GA_SCOPES
+    )
+    body = _build_ga_query(view_id, start_date, end_date)
+    response = service.reports().batchGet(body=body).execute()
+
+    if 'rows' in response['reports'][0]['data']:
+        return [row for row in response['reports'][0]['data']['rows']]
+    else:
+        return []
+
+
+def _get_start_date(latest_date=None):
+    '''Determine when data collection should start.
+
+    :latest_date: the most recent date data was collected for this domain, if
+        it exists
+    '''
+    default_start = \
+        dateutil.parser.parse(GOOGLE_API_GA_TABLE_DEFAULT_FROM_DATE).date()
+    if latest_date:
+        return max(latest_date, default_start)
+    else:
+        return default_start
+
+
+def _get_requested_period_date_range(latest_date=None):
+    '''Determine and return the required start_date and end_date'''
+    start_date = _get_start_date(latest_date)
+    end_date = datetime.date.today() - datetime.timedelta(days=1)
+    return start_date, end_date
+
+
+def ga_collector(domain, view_id, latest_date):
+    start_date_of_requested_period, end_date_of_requested_period = \
+        _get_requested_period_date_range(latest_date)
+
+    api_response = _request_data_from_ga(domain, view_id,
+                                         start_date_of_requested_period,
+                                         end_date_of_requested_period)
+
+    resource_content = []
+    for row in api_response:
+        metrics = row['metrics'][0]['values']
+        res_row = {
+            'source': 'ga',
+            'domain': domain,
+            'date': dateutil.parser.parse(row['dimensions'][0]).date(),
+            'visitors': int(metrics[0]),
+            'unique_visitors': int(metrics[1]),
+            'avg_time_spent': round(float(metrics[2]))
+        }
+        resource_content.append(res_row)
+
+    return resource_content
+
+
+parameters, datapackage, res_iter = ingest()
+
+domain_url = parameters['domain']['url']
+domain_view_id = parameters['domain']['viewid']
+resource = {
+    'name': slugify(domain_url),
+    'path': 'data/{}.csv'.format(slugify(domain_url))
+}
+
+headers = ['domain', 'source', 'date', 'visitors', 'unique_visitors',
+           'avg_time_spent']
+resource['schema'] = {'fields': [{'name': h, 'type': 'string'}
+                                 for h in headers]}
+
+datapackage['resources'].append(resource)
+
+
+def process_resources(res_iter, datapackage, domain, view_id):
+
+    def get_latest_date(first):
+        latest_date = None
+        my_rows = []
+        for row in first:
+            if row['domain'] == domain and row['source'] == 'ga':
+                latest_date = row['date']
+            my_rows.append(row)
+        return latest_date, iter(my_rows)
+
+    if len(datapackage['resources']):
+        if datapackage['resources'][0]['name'] == 'latest-project-entries':
+            latest_date, latest_iter = get_latest_date(next(res_iter))
+            yield latest_iter
+        else:
+            latest_date = None
+    yield from res_iter
+    yield ga_collector(domain, view_id, latest_date)
+
+
+spew(datapackage, process_resources(res_iter, datapackage,
+                                    domain_url, domain_view_id))

--- a/datapackage_pipelines_measure/processors/google_utils.py
+++ b/datapackage_pipelines_measure/processors/google_utils.py
@@ -11,6 +11,11 @@ GOOGLE_API_BIGQUERY_VERSION = 'v2'
 GOOGLE_API_BIGQUERY_SERVICE_NAME = 'bigquery'
 GOOGLE_API_BIGQUERY_SCOPES = \
     'https://www.googleapis.com/auth/bigquery'
+
+GOOGLE_API_GA_SERVICE_NAME = 'analyticsreporting'
+GOOGLE_API_GA_VERSION = 'v4'
+GOOGLE_API_GA_SCOPES = 'https://www.googleapis.com/auth/analytics.readonly'
+
 JWT_NAMESPACE = 'GOOGLE_API_JWT_'
 
 

--- a/datapackage_pipelines_measure/schemas/measure_spec_schema.json
+++ b/datapackage_pipelines_measure/schemas/measure_spec_schema.json
@@ -65,6 +65,29 @@
               "required": ["packages"]
             }
           }
+        },
+        "website-analytics": {
+          "type": "object",
+          "properties": {
+            "ga": {
+              "type": "object",
+              "properties": {
+                "domains": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "url": {"type": "string"},
+                      "viewid": {"type": ["string", "integer"]}
+                    },
+                    "required": ["url", "viewid"]
+                  },
+                  "minItems": 1
+                }
+              },
+              "required": ["domains"]
+            }
+          }
         }
       }
     }

--- a/projects/frictionlessdata/measure.source-spec.yaml
+++ b/projects/frictionlessdata/measure.source-spec.yaml
@@ -51,3 +51,11 @@ config:
         - "frictionlessdata/datapackage-r"
         - "frictionlessdata/datapackagist"
         - "frictionlessdata/goodtables-js"
+
+  website-analytics:
+    ga:
+      domains:
+        - url: 'frictionlessdata.io'
+          viewid: '120195554'
+        - url: 'specs.frictionlessdata.io'
+          viewid: '57520245'

--- a/tests/test_ga_processor.py
+++ b/tests/test_ga_processor.py
@@ -1,0 +1,255 @@
+import os
+import mock
+import dateutil
+import unittest
+
+from datapackage_pipelines.utilities.lib_test_helpers import (
+    mock_processor_test
+)
+
+import datapackage_pipelines_measure.processors
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class TestMeasureGAProcessor(unittest.TestCase):
+
+    @mock.patch(
+        'datapackage_pipelines_measure.processors.google_utils.discovery')
+    def test_add_ga_resource_processor_no_latest(self, mock_discovery):
+        '''No latest in db, so populate from GA request.'''
+
+        ga_response = {
+            'reports': [
+                {
+                    'data': {
+                        'rows': [
+                            {'dimensions': ['20170515'],
+                             'metrics': [{'values': ['1', '1', '2.0']}]},
+                            {'dimensions': ['20170516'],
+                             'metrics': [{'values': ['3', '5', '8.0']}]},
+                            {'dimensions': ['20170517'],
+                             'metrics': [{'values': ['13', '21', '34.0']}]},
+                            {'dimensions': ['20170518'],
+                             'metrics': [{'values': ['55', '89', '144.0']}]}
+                        ]
+                    }
+                }
+            ]
+        }
+
+        mock_discovery \
+            .build.return_value \
+            .reports.return_value \
+            .batchGet.return_value \
+            .execute.return_value = ga_response
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []  # nothing here
+        }
+        params = {
+            'domain': {
+                'url': 'sub.example.com',
+                'viewid': '123456'
+            }
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir, 'add_ga_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, iter([])))
+
+        # spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # one resource
+        resources = list(spew_res_iter)
+        assert len(resources) == 1
+
+        # rows in resource
+        rows = list(resources)[0]
+        assert len(rows) == 4
+        # first row asserts
+        assert rows[0] == {
+            'date': dateutil.parser.parse('2017-05-15').date(),
+            'visitors': 1,
+            'unique_visitors': 1,
+            'avg_time_spent': 2,
+            'domain': 'sub.example.com',
+            'source': 'ga'
+        }
+        # last row asserts
+        assert rows[len(rows)-1]['visitors'] == 55
+        assert rows[len(rows)-1]['unique_visitors'] == 89
+        assert rows[len(rows)-1]['avg_time_spent'] == 144
+        assert rows[len(rows)-1]['date'] == \
+            dateutil.parser.parse('2017-05-18').date()
+
+    @mock.patch(
+        'datapackage_pipelines_measure.processors.google_utils.discovery')
+    def test_add_ga_resource_processor_latest_week_old(self, mock_discovery):
+        '''Latest in db is a week old, so fetch new data.'''
+
+        ga_response = {
+            'reports': [
+                {
+                    'data': {
+                        'rows': [
+                            {'dimensions': ['20170515'],
+                             'metrics': [{'values': ['1', '1', '2.0']}]},
+                            {'dimensions': ['20170516'],
+                             'metrics': [{'values': ['3', '5', '8.0']}]},
+                            {'dimensions': ['20170517'],
+                             'metrics': [{'values': ['13', '21', '34.0']}]},
+                            {'dimensions': ['20170518'],
+                             'metrics': [{'values': ['55', '89', '144.0']}]}
+                        ]
+                    }
+                }
+            ]
+        }
+
+        mock_discovery \
+            .build.return_value \
+            .reports.return_value \
+            .batchGet.return_value \
+            .execute.return_value = ga_response
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': [{
+                'name': 'latest-project-entries',
+                'schema': {
+                    'fields': [
+                        {'name': 'date', 'type': 'date'},
+                        {'name': 'visitors', 'type': 'int'},
+                        {'name': 'unique_visitors', 'type': 'int'},
+                        {'name': 'domain', 'type': 'string'},
+                        {'name': 'avg_time_spent', 'type': 'number'},
+                        {'name': 'source', 'type': 'string'},
+                    ]
+                }
+            }]
+        }
+        params = {
+            'domain': {
+                'url': 'sub.example.com',
+                'viewid': '123456'
+            }
+        }
+
+        def latest_entries_res():
+            yield {
+                    'date': dateutil.parser.parse('2017-05-14').date(),
+                    'visitors': 3,
+                    'unique_visitors': 5,
+                    'avg_time_spent': 12,
+                    'domain': 'sub.example.com',
+                    'source': 'ga'
+                }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir, 'add_ga_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = \
+            mock_processor_test(processor_path,
+                                (params, datapackage,
+                                 iter([latest_entries_res()])))
+
+        # spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # one resource
+        resources = list(spew_res_iter)
+        assert len(resources) == 2
+
+        # first resource will look like latest_entries_res
+        assert list(resources[0])[0] == next(latest_entries_res())
+
+        # rows in resource
+        rows = list(resources)[1]
+        assert len(rows) == 4
+        # first row asserts
+        assert rows[0] == {
+            'date': dateutil.parser.parse('2017-05-15').date(),
+            'visitors': 1,
+            'unique_visitors': 1,
+            'avg_time_spent': 2,
+            'domain': 'sub.example.com',
+            'source': 'ga'
+        }
+        # last row asserts
+        assert rows[len(rows)-1]['visitors'] == 55
+        assert rows[len(rows)-1]['unique_visitors'] == 89
+        assert rows[len(rows)-1]['avg_time_spent'] == 144
+        assert rows[len(rows)-1]['date'] == \
+            dateutil.parser.parse('2017-05-18').date()
+
+    @mock.patch(
+        'datapackage_pipelines_measure.processors.google_utils.discovery')
+    def test_add_ga_resource_processor_no_row_returned(self, mock_discovery):
+        '''No rows returned from GA response.'''
+
+        ga_response = {
+            'reports': [
+                {
+                    'data': {}
+                }
+            ]
+        }
+
+        mock_discovery \
+            .build.return_value \
+            .reports.return_value \
+            .batchGet.return_value \
+            .execute.return_value = ga_response
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []
+        }
+        params = {
+            'domain': {
+                'url': 'sub.example.com',
+                'viewid': '123456'
+            }
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir, 'add_ga_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = \
+            mock_processor_test(processor_path,
+                                (params, datapackage, iter([])))
+
+        # spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # one resource
+        resources = list(spew_res_iter)
+        assert len(resources) == 1
+
+        # rows in resource
+        rows = list(resources)[0]
+        assert len(rows) == 0


### PR DESCRIPTION
This pull request fixes #31. Connected to #3.

* [x] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- Adds a `website-analytics` pipeline
- Adds a `add_ga_resource` processer to the new pipeline
- add_ga_processor collects data from google analytics about a specified `domain` and `viewid`:
  - `visitors`
  - `unique_visitors`
  - `avg_time_spent`
