### PR TITLE
Twitter processor can search for url entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,21 @@ The PyPI processor requires a Google API account with generated credential to ma
 
 #### Twitter
 
-The Twitter processor collects data about each entity listed in the `entities` section. Entities can be either a twitter hashtag (starting with `#`) or an account name (starting with a `@`). For each entity, the processor collects:
+The Twitter processor collects data about each entity listed in the `entities` section. Entities can be one of the following:
+
+- `#hashtag`: a twitter hash tag
+- `@account`: an account name
+- `url:search-term`: a search term as part of a url
+
+For each entity, the processor collects:
 
 - **mentions**: total of tweets mentioning the entity for the period (day)
 - **interactions**: total of 'favorites' and 'retweets' for tweets mentioning the hashtag, or tweets authored by the account, for the period (day).
 
 And additionally, for account entities:
 - the current number of **followers**
+
+Url search terms are used to find urls mentioned in tweets. It is best to leave off `http://` prefixes. Urls searches for just the domain will be less specific (will return more results) than for url searches that include a path, e.g.: `url:blog.okfn.org` will return more results than the more specific search, `url:blog.okfn.org/2017/`, which in turn will return more results than `url:blog.okfn.org/2017/06/15/the-final-global-open-data-index-is-now-live/`.
 
 ```yaml
 config:
@@ -151,6 +159,7 @@ config:
         - "#frictionlessdata"
         - "#datapackages"
         - "@okfnlabs"
+        - "url:frictionlessdata.io"
 ```
 
 

--- a/datapackage_pipelines_measure/processors/add_twitter_resource.py
+++ b/datapackage_pipelines_measure/processors/add_twitter_resource.py
@@ -15,7 +15,8 @@ log = logging.getLogger(__name__)
 
 tweepy_cursor = tweepy.Cursor
 
-ENTITY_VALUE_ERROR_MSG = 'Entity, "{}", must be an @account or a #hashtag'
+ENTITY_VALUE_ERROR_MSG = 'Entity, "{}", must be an @account, #hashtag, ' \
+                         'or url:url-search'
 TWITTER_API_USER_NOT_FOUND_ERROR_CODE = "50"
 TWITTER_API_DATE_RANGE_FORMAT = '%Y-%m-%d'
 TWITTER_API_PER_PAGE_LIMIT = 100
@@ -30,6 +31,8 @@ def _get_entity_type(entity):
         return 'account'
     elif entity.startswith('#'):
         return 'hashtag'
+    elif entity.startswith('url:'):
+        return 'url'
     else:
         raise ValueError(ENTITY_VALUE_ERROR_MSG.format(entity))
 
@@ -40,6 +43,8 @@ def _get_safe_entity(entity):
         return 'at-{}'.format(slugify(entity))
     elif entity.startswith('#'):
         return 'hash-{}'.format(slugify(entity))
+    elif entity.startswith('url:'):
+        return slugify(entity)
     else:
         raise ValueError(ENTITY_VALUE_ERROR_MSG.format(entity))
 
@@ -169,10 +174,10 @@ def _get_interactions_for_entity_from_source(entity, start_date, end_date):
         measured 'interaction' metrics - favorites and retweets.
         '''
         tweets = _get_account_tweets(entity, start_date, end_date)
-    elif entity_type == 'hashtag':
+    elif entity_type == 'hashtag' or entity_type == 'url':
         '''
-        Get interactions for a hashtag entity. This is done by searching for
-        the hashtag between the given date range, and aggregate the measured
+        Get interactions for a hashtag or url entity. This is done by searching
+        for the entity between the given date range, and aggregate the measured
         'interaction' metrics - favorites and retweets.
         '''
         tweets = _get_twitter_search_results(entity, start_date, end_date)

--- a/projects/frictionlessdata/measure.source-spec.yaml
+++ b/projects/frictionlessdata/measure.source-spec.yaml
@@ -8,6 +8,7 @@ config:
         - "#frictionlessdata"
         - "#datapackages"
         - "@okfnlabs"
+        - "url:frictionlessdata.io"
     facebook:
       pages:
         - "OKFNetwork"

--- a/projects/godi/measure.source-spec.yaml
+++ b/projects/godi/measure.source-spec.yaml
@@ -6,6 +6,7 @@ config:
     twitter:
       entities:
         - "#godi16"
+        - "url:index.okfn.org"
 
   code-hosting:
     github:


### PR DESCRIPTION
Twitter processor can be used to report for `url:search-term` formatted entities.

This pull request fixes #34.

* [x] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- `url:search-term` added as an allowable twitter processor entity
