### PR TITLE
RubyGems processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ Potentially, we'd love to see interest from other non-profits who receive funds 
 
 ## Project Configuration
 
+
+<!-- MarkdownTOC autolink="true" bracket="round" depth=3 -->
+
+  - [Code Hosting](#code-hosting)
+    - [Github](#github)
+  - [Code Packaging](#code-packaging)
+    - [NPM](#npm)
+    - [PyPI](#pypi)
+    - [RubyGems](#rubygems)
+  - [Social Media](#social-media)
+    - [Twitter](#twitter)
+    - [Facebook](#facebook)
+  - [Website Analytics](#website-analytics)
+    - [Google Analytics](#google-analytics)
+  - [Outputs](#outputs)
+    - [Outputs Captured by Google Forms](#outputs-captured-by-google-forms)
+- [Environmental Variables](#environmental-variables)
+  - [General](#general)
+  - [Github](#github-1)
+  - [Twitter](#twitter-1)
+  - [Facebook](#facebook-1)
+  - [Google credentials for PyPI, Google analytics, and Outputs](#google-credentials-for-pypi-google-analytics-and-outputs)
+
+<!-- /MarkdownTOC -->
+
 Each project has a `measure.source-spec.yaml` configuration file within a project directory in `/projects`, e.g. for the Frictionless Data project:
 
 ```
@@ -130,6 +155,24 @@ The PyPI processor requires a Google API account with generated credential to ma
 1. Click on **Options** symbol for **App Engine default service account**, click **Create Key**
 1. Choose Key Type to be **JSON**
 1. The downloaded file will have all the credentials you need. Keep them safe, and use them to [populate the environmental variables below](#pypi-1).
+
+#### RubyGems
+
+The RubyGems processor collects gem package download data from the rubygems.org API.
+
+- **total_downloads**: collected directly from the API
+- **downloads**: daily downloads calculated from yesterday's `total_downloads` value, if present.
+
+```yaml
+config:
+  code-packaging:
+    rubygems:
+      gems:
+        - "tableschema"
+        - "datapackage"
+```
+
+No historical download data is collected for RubyGems.
 
 ### Social Media
 

--- a/datapackage_pipelines_measure/pipeline_steps/code_packaging.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_packaging.py
@@ -31,6 +31,12 @@ def add_steps(steps: list, pipeline_id: str,
                 'package': slugify(package)
             }))
 
+    if 'rubygems' in config:
+        for gem in config['rubygems']['gems']:
+            steps.append(('measure.add_rubygems_resource', {
+                'gem_id': gem
+            }))
+
     steps.append(('measure.remove_resource', {
         'name': 'latest-project-entries'
     }))
@@ -42,6 +48,7 @@ def add_steps(steps: list, pipeline_id: str,
         'fields': {
             'date': [],
             'downloads': [],
+            'total_downloads': [],
             'source': [],
             'package': []}
     }))
@@ -49,6 +56,9 @@ def add_steps(steps: list, pipeline_id: str,
     steps.append(('set_types', {
         'types': {
             'downloads': {
+                'type': 'integer'
+            },
+            'total_downloads': {
                 'type': 'integer'
             },
             'source': {

--- a/datapackage_pipelines_measure/processors/add_rubygems_resource.py
+++ b/datapackage_pipelines_measure/processors/add_rubygems_resource.py
@@ -1,0 +1,107 @@
+import datetime
+
+import simplejson
+import requests
+
+from datapackage_pipelines.generators import slugify
+from datapackage_pipelines.wrapper import ingest, spew
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def _request_data_from_rubygems(endpoint):
+    '''Request data and handle errors from rubygems.org REST API.'''
+
+    rubygems_url = 'https://rubygems.org/api/v1{endpoint}' \
+        .format(endpoint=endpoint)
+
+    rubygems_response = requests.get(rubygems_url)
+
+    if (rubygems_response.status_code != 200):
+        log.error('An error occurred fetching Rubygems data: {}'
+                  .format(rubygems_response.text))
+        raise Exception(rubygems_response.text)
+
+    try:
+        json_response = rubygems_response.json()
+    except simplejson.scanner.JSONDecodeError as e:
+        log.error('Expected JSON in response from: {}'.format(rubygems_url))
+        raise e
+
+    return json_response
+
+
+def _request_gem_stats_from_rubygems(gem_id):
+    '''Request general info for a gem_id.'''
+    endpoint = '/gems/{gem_id}.json'.format(gem_id=gem_id)
+    json_response = _request_data_from_rubygems(endpoint)
+    return json_response
+
+
+def rubygems_collector(gem_id, latest_row):
+    gem_info = _request_gem_stats_from_rubygems(gem_id)
+
+    total_downloads = gem_info['downloads']
+
+    today = datetime.date.today()
+    yesterday = today - datetime.timedelta(days=1)
+    res_row = {
+        'total_downloads': total_downloads,
+        'date': today,
+        'package': gem_id,
+        'source': 'rubygems'
+    }
+
+    # Calculate daily downloads from total_downloads.
+    if latest_row:
+        if latest_row['date'] == yesterday:
+            res_row['downloads'] = \
+                total_downloads - latest_row['total_downloads']
+        # If latest is today, retain `downloads` value.
+        elif latest_row['date'] == today:
+            res_row['downloads'] = latest_row['downloads']
+
+    resource_content = []
+    resource_content.append(res_row)
+
+    return resource_content
+
+
+parameters, datapackage, res_iter = ingest()
+
+gem_id = parameters['gem_id']
+resource = {
+    'name': slugify(gem_id),
+    'path': 'data/{}.csv'.format(slugify(gem_id))
+}
+
+headers = ['source', 'date', 'package', 'downloads', 'total_downloads']
+resource['schema'] = {'fields': [{'name': h, 'type': 'string'}
+                                 for h in headers]}
+
+datapackage['resources'].append(resource)
+
+
+def process_resources(res_iter, datapackage, gem_id):
+
+    def get_latest_row(first):
+        latest_row = None
+        my_rows = []
+        for row in first:
+            if row['package'] == gem_id and row['source'] == 'rubygems':
+                latest_row = row
+            my_rows.append(row)
+        return latest_row, iter(my_rows)
+
+    if len(datapackage['resources']):
+        if datapackage['resources'][0]['name'] == 'latest-project-entries':
+            latest_row, latest_iter = get_latest_row(next(res_iter))
+            yield latest_iter
+        else:
+            latest_row = None
+    yield from res_iter
+    yield rubygems_collector(gem_id, latest_row)
+
+
+spew(datapackage, process_resources(res_iter, datapackage, gem_id))

--- a/datapackage_pipelines_measure/schemas/measure_spec_schema.json
+++ b/datapackage_pipelines_measure/schemas/measure_spec_schema.json
@@ -63,6 +63,15 @@
                 }
               },
               "required": ["packages"]
+            },
+            "rubygems": {
+              "type": "object",
+              "properties": {
+                "gems": {
+                  "type": "array"
+                }
+              },
+              "required": ["gems"]
             }
           }
         },

--- a/projects/frictionlessdata/measure.source-spec.yaml
+++ b/projects/frictionlessdata/measure.source-spec.yaml
@@ -28,6 +28,10 @@ config:
         - 'jsontableschema-sql'
         - 'jsontableschema-bigquery'
         - 'jsontableschema-pandas'
+    rubygems:
+      gems:
+        - 'tableschema'
+        - 'datapackage'
 
   code-hosting:
     github:

--- a/tests/test_github_processor.py
+++ b/tests/test_github_processor.py
@@ -57,9 +57,8 @@ class TestMeasureGithubProcessor(unittest.TestCase):
 
         # Trigger the processor with our mock `ingest` and capture what it will
         # returned to `spew`.
-        spew_args, _ = \
-            mock_processor_test(processor_path,
-                                (params, datapackage, []))
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, []))
 
         spew_dp = spew_args[0]
         spew_res_iter = spew_args[1]

--- a/tests/test_rubygems_processor.py
+++ b/tests/test_rubygems_processor.py
@@ -1,0 +1,300 @@
+import os
+import datetime
+import unittest
+
+import simplejson
+import requests_mock
+
+from datapackage_pipelines.utilities.lib_test_helpers import (
+    mock_processor_test
+)
+
+import datapackage_pipelines_measure.processors
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class TestMeasureRubygemsProcessor(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_add_rubygems_resource_processor(self, mock_request):
+        '''No latest in database. Get today's data.'''
+        # mock the rubygems response
+        mock_rubygems_response = {
+            'name': 'mygem',
+            'downloads': 271,
+            'version': '0.3.1',
+            'version_downloads': 170
+        }
+        mock_request.get('https://rubygems.org/api/v1/gems/mygem.json',
+                         json=mock_rubygems_response)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []
+        }
+        params = {
+            'gem_id': 'mygem'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_rubygems_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, []))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # Asserts for the datapackage
+        dp_resources = spew_dp['resources']
+        assert len(dp_resources) == 1
+        assert dp_resources[0]['name'] == 'mygem'
+        field_names = \
+            [field['name'] for field in dp_resources[0]['schema']['fields']]
+        assert field_names == ['source', 'date', 'package', 'downloads',
+                               'total_downloads']
+
+        # Asserts for the res_iter
+        spew_res_iter_contents = list(spew_res_iter)
+        assert len(spew_res_iter_contents) == 1
+        assert list(spew_res_iter_contents[0]) == \
+            [{
+                'package': 'mygem',
+                'source': 'rubygems',
+                'total_downloads': 271,
+                'date': datetime.date.today()
+            }]
+
+    @requests_mock.mock()
+    def test_add_rubygems_resource_processor_latest_yesterday(self,
+                                                              mock_request):
+        '''Latest was yesterday. Get today's data, and add `downloads`.'''
+        # mock the rubygems response
+        mock_rubygems_response = {
+            'name': 'mygem',
+            'downloads': 271,
+            'version': '0.3.1',
+            'version_downloads': 170
+        }
+        mock_request.get('https://rubygems.org/api/v1/gems/mygem.json',
+                         json=mock_rubygems_response)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': [{
+                'name': 'latest-project-entries',
+                'schema': {
+                    'fields': [
+                        {'name': 'source', 'type': 'string'},
+                        {'name': 'date', 'type': 'date'},
+                        {'name': 'package', 'type': 'string'},
+                        {'name': 'downloads', 'type': 'int'},
+                        {'name': 'total_downloads', 'type': 'int'}
+                    ]
+                }
+            }]
+        }
+        params = {
+            'gem_id': 'mygem'
+        }
+
+        # latest is yest
+        def latest_entries_res():
+            yield {
+                    'date': datetime.date.today() - datetime.timedelta(days=1),
+                    'downloads': 7,
+                    'total_downloads': 265,
+                    'package': 'mygem',
+                    'source': 'rubygems'
+                }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_rubygems_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage,
+                                            iter([latest_entries_res()])))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # Asserts for the datapackage
+        dp_resources = spew_dp['resources']
+        assert len(dp_resources) == 2
+        assert dp_resources[0]['name'] == 'latest-project-entries'
+        assert dp_resources[1]['name'] == 'mygem'
+        field_names = \
+            [field['name'] for field in dp_resources[0]['schema']['fields']]
+        assert field_names == ['source', 'date', 'package', 'downloads',
+                               'total_downloads']
+
+        # Asserts for the res_iter
+        spew_res_iter_contents = list(spew_res_iter)
+        assert len(spew_res_iter_contents) == 2
+        assert list(spew_res_iter_contents[1]) == \
+            [{
+                'package': 'mygem',
+                'source': 'rubygems',
+                'downloads': 6,
+                'total_downloads': 271,
+                'date': datetime.date.today()
+            }]
+
+    @requests_mock.mock()
+    def test_add_rubygems_resource_processor_latest_today(self,
+                                                              mock_request):
+        '''Latest is today. Get today's data, ensure `downloads` is
+        retained.'''
+        # mock the rubygems response
+        mock_rubygems_response = {
+            'name': 'mygem',
+            'downloads': 271,
+            'version': '0.3.1',
+            'version_downloads': 170
+        }
+        mock_request.get('https://rubygems.org/api/v1/gems/mygem.json',
+                         json=mock_rubygems_response)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': [{
+                'name': 'latest-project-entries',
+                'schema': {
+                    'fields': [
+                        {'name': 'source', 'type': 'string'},
+                        {'name': 'date', 'type': 'date'},
+                        {'name': 'package', 'type': 'string'},
+                        {'name': 'downloads', 'type': 'int'},
+                        {'name': 'total_downloads', 'type': 'int'}
+                    ]
+                }
+            }]
+        }
+        params = {
+            'gem_id': 'mygem'
+        }
+
+        # latest is yest
+        def latest_entries_res():
+            yield {
+                    'date': datetime.date.today(),
+                    'downloads': 7,
+                    'total_downloads': 265,
+                    'package': 'mygem',
+                    'source': 'rubygems'
+                }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_rubygems_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage,
+                                            iter([latest_entries_res()])))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # Asserts for the datapackage
+        dp_resources = spew_dp['resources']
+        assert dp_resources[1]['name'] == 'mygem'
+
+        # Asserts for the res_iter
+        spew_res_iter_contents = list(spew_res_iter)
+        assert list(spew_res_iter_contents[1]) == \
+            [{
+                'package': 'mygem',
+                'source': 'rubygems',
+                'downloads': 7,
+                'total_downloads': 271,
+                'date': datetime.date.today()
+            }]
+
+    @requests_mock.Mocker()
+    def test_add_rubygems_resource_not_json(self, mock_request):
+        # Mock API responses
+        mock_request.get('https://rubygems.org/api/v1/gems/mygem404.json',
+                         text="This is not json.")
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []  # nothing here
+        }
+        params = {
+            'gem_id': 'mygem404'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_rubygems_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, iter([])))
+
+        # Trigger the processor with our mock `ingest` will return an exception
+        with self.assertRaises(simplejson.scanner.JSONDecodeError):
+            spew_res_iter = spew_args[1]
+            # attempt access to spew_res_iter raises exception
+            list(spew_res_iter)
+
+    @requests_mock.Mocker()
+    def test_add_rubygems_resource_bad_status(self, mock_request):
+        # Mock API responses
+        mock_request.get('https://rubygems.org/api/v1/gems/mygem401.json',
+                         text='Hi, there was a problem with your request.',
+                         status_code=401)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []  # nothing here
+        }
+        params = {
+            'gem_id': 'mygem401'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_rubygems_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, iter([])))
+
+        # Trigger the processor with our mock `ingest` will return an exception
+        with self.assertRaises(Exception):
+            spew_res_iter = spew_args[1]
+            # attempt access to spew_res_iter raises exception
+            list(spew_res_iter)


### PR DESCRIPTION
This pull request fixes #40.

* [x] I've added tests to cover the proposed changes

Adds a `add_rubygems_resource` processor to the `code-packaging` pipeline. Processor collects `total_downloads` directly from the rubygems.org API, and calculates a daily `downloads` value by comparing today's total_downloads with yesterday's.

Historical data isn't available from rubygems.org.
