### PR TITLE
Packagist processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Potentially, we'd love to see interest from other non-profits who receive funds 
     - [NPM](#npm)
     - [PyPI](#pypi)
     - [RubyGems](#rubygems)
+    - [Packagist](#packagist)
   - [Social Media](#social-media)
     - [Twitter](#twitter)
     - [Facebook](#facebook)
@@ -161,7 +162,7 @@ The PyPI processor requires a Google API account with generated credential to ma
 
 #### RubyGems
 
-The RubyGems processor collects gem package download data from the rubygems.org API.
+The RubyGems processor collects ruby gem download data from the rubygems.org API.
 
 - **total_downloads**: collected directly from the API
 - **downloads**: daily downloads calculated from yesterday's `total_downloads` value, if present.
@@ -176,6 +177,26 @@ config:
 ```
 
 No historical download data is collected for RubyGems.
+
+#### Packagist
+
+The Packagist processor collects PHP package daily download data from the packagist.org API.
+
+- **downloads**: daily downloads collected directly from the API.
+
+```yaml
+config:
+  code-packaging:
+    packagist:
+      packages:
+        - "frictionlessdata/tableschema"
+        - "frictionlessdata/datapackage"
+```
+
+Note: `packages` defined in the config must include their owner organization in the form `organization_name/package_name`.
+
+Results from the Packagist.org API appear to be a couple of days behind.
+
 
 ### Social Media
 

--- a/datapackage_pipelines_measure/pipeline_steps/code_packaging.py
+++ b/datapackage_pipelines_measure/pipeline_steps/code_packaging.py
@@ -37,6 +37,12 @@ def add_steps(steps: list, pipeline_id: str,
                 'gem_id': gem
             }))
 
+    if 'packagist' in config:
+        for package in config['packagist']['packages']:
+            steps.append(('measure.add_packagist_resource', {
+                'package': package
+            }))
+
     steps.append(('measure.remove_resource', {
         'name': 'latest-project-entries'
     }))

--- a/datapackage_pipelines_measure/processors/add_packagist_resource.py
+++ b/datapackage_pipelines_measure/processors/add_packagist_resource.py
@@ -1,0 +1,108 @@
+import dateutil
+from collections import OrderedDict
+
+import simplejson
+import requests
+
+from datapackage_pipelines.generators import slugify
+from datapackage_pipelines.wrapper import ingest, spew
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def _request_data_from_packagist(endpoint):
+    '''Request data and handle errors from packagist.org REST API.'''
+
+    packagist_url = 'https://packagist.org{endpoint}' \
+        .format(endpoint=endpoint)
+
+    packagist_response = requests.get(packagist_url)
+
+    if (packagist_response.status_code != 200):
+        log.error('An error occurred fetching Packagist data: {}'
+                  .format(packagist_response.text))
+        raise Exception(packagist_response.text)
+
+    try:
+        json_response = packagist_response.json()
+    except simplejson.scanner.JSONDecodeError as e:
+        log.error('Expected JSON in response from: {}'.format(packagist_url))
+        raise e
+
+    return json_response
+
+
+def _request_package_stats_from_packagist(package):
+    '''Request general info for a package.'''
+    endpoint = '/packages/{package}/stats/all.json'.format(package=package)
+    json_response = _request_data_from_packagist(endpoint)
+    return json_response
+
+
+def packagist_collector(package, latest_row):
+    package_info = _request_package_stats_from_packagist(package)
+    download_by_date = dict(zip(package_info['labels'],
+                                package_info['values']))
+
+    if latest_row:
+        # If there's a latest_row, reject all items in download_by_date before
+        # latest_row date
+        latest_row_date_str = latest_row['date'].strftime('%Y-%m-%d')
+        download_by_date = {k: v for k, v in download_by_date.items()
+                            if k >= latest_row_date_str}
+
+    # ensure dict is ordered by date key
+    download_by_date = OrderedDict(sorted(download_by_date.items()))
+
+    resource_content = []
+    for k, v in download_by_date.items():
+        res_row = {
+            'package': package.split('/')[-1],
+            'source': 'packagist',
+            'date': dateutil.parser.parse(k).date(),
+            'downloads': v
+        }
+        resource_content.append(res_row)
+
+    return resource_content
+
+
+parameters, datapackage, res_iter = ingest()
+
+package = parameters['package']
+resource = {
+    'name': slugify(package),
+    'path': 'data/{}.csv'.format(slugify(package))
+}
+
+headers = ['package', 'source', 'date', 'downloads']
+resource['schema'] = {'fields': [{'name': h, 'type': 'string'}
+                                 for h in headers]}
+
+datapackage['resources'].append(resource)
+
+
+def process_resources(res_iter, datapackage, package):
+
+    def get_latest_row(first):
+        latest_row = None
+        package_name = package.split('/')[-1]
+        my_rows = []
+        for row in first:
+            if row['package'] == package_name and row['source'] == 'packagist':
+                latest_row = row
+            my_rows.append(row)
+        return latest_row, iter(my_rows)
+
+    if len(datapackage['resources']):
+        if datapackage['resources'][0]['name'] == 'latest-project-entries':
+            latest_row, latest_iter = get_latest_row(next(res_iter))
+            yield latest_iter
+        else:
+            latest_row = None
+    yield from res_iter
+    yield packagist_collector(package, latest_row)
+
+
+spew(datapackage, process_resources(res_iter, datapackage, package))

--- a/datapackage_pipelines_measure/schemas/measure_spec_schema.json
+++ b/datapackage_pipelines_measure/schemas/measure_spec_schema.json
@@ -72,6 +72,15 @@
                 }
               },
               "required": ["gems"]
+            },
+            "packagist": {
+              "type": "object",
+              "properties": {
+                "packages": {
+                  "type": "array"
+                }
+              },
+              "required": ["packages"]
             }
           }
         },

--- a/projects/frictionlessdata/measure.source-spec.yaml
+++ b/projects/frictionlessdata/measure.source-spec.yaml
@@ -32,6 +32,10 @@ config:
       gems:
         - 'tableschema'
         - 'datapackage'
+    packagist:
+      packages:
+        - 'frictionlessdata/tableschema'
+        - 'frictionlessdata/datapackage'
 
   code-hosting:
     github:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(*paths):
 PACKAGE = 'datapackage_pipelines_measure'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
-    'datapackage-pipelines',
+    'datapackage-pipelines==1.0.19',
     'psycopg2',
     'tweepy',
     'facebook-sdk',

--- a/tests/test_packagist_processor.py
+++ b/tests/test_packagist_processor.py
@@ -1,0 +1,228 @@
+import os
+import dateutil
+import datetime
+import unittest
+
+import simplejson
+import requests_mock
+
+from datapackage_pipelines.utilities.lib_test_helpers import (
+    mock_processor_test
+)
+
+import datapackage_pipelines_measure.processors
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class TestMeasurePackagistProcessor(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_add_packagist_resource_processor(self, mock_request):
+        '''No latest in database. Use all returned data.'''
+        # mock the packagist response
+        mock_packagist_response = {"labels":["2017-04-17","2017-04-18","2017-04-19","2017-04-20","2017-04-21"],"values":[1,2,3,4,5],"average":"daily"}  # noqa
+        mock_request.get('https://packagist.org/packages/organization/mypackage/stats/all.json',  # noqa
+                         json=mock_packagist_response)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []
+        }
+        params = {
+            'package': 'organization/mypackage'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_packagist_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, []))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # Asserts for the datapackage
+        dp_resources = spew_dp['resources']
+        assert len(dp_resources) == 1
+        assert dp_resources[0]['name'] == 'organization-mypackage'
+        field_names = \
+            [field['name'] for field in dp_resources[0]['schema']['fields']]
+        assert field_names == ['package', 'source', 'date', 'downloads']
+
+        # Asserts for the res_iter
+        spew_res_iter_contents = list(spew_res_iter)
+        assert len(spew_res_iter_contents) == 1
+        rows = list(spew_res_iter_contents[0])
+        assert len(rows) == 5
+        assert rows[0] == \
+            {
+                'package': 'mypackage',
+                'source': 'packagist',
+                'downloads': 1,
+                'date': dateutil.parser.parse('2017-04-17').date()
+            }
+        assert rows[4] == \
+            {
+                'package': 'mypackage',
+                'source': 'packagist',
+                'downloads': 5,
+                'date': dateutil.parser.parse('2017-04-21').date()
+            }
+
+    @requests_mock.mock()
+    def test_add_packagist_resource_processor_latest_exists(self,
+                                                            mock_request):
+        '''Latest in database exists in returned data. Use only more recent.'''
+        # mock the packagist response
+        mock_packagist_response = {"labels":["2017-04-17","2017-04-18","2017-04-19","2017-04-20","2017-04-21"],"values":[1,2,3,4,5],"average":"daily"}  # noqa
+        mock_request.get('https://packagist.org/packages/organization/mypackage/stats/all.json',  # noqa
+                         json=mock_packagist_response)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': [{
+                'name': 'latest-project-entries',
+                'schema': {
+                    'fields': [
+                        {'name': 'source', 'type': 'string'},
+                        {'name': 'date', 'type': 'date'},
+                        {'name': 'package', 'type': 'string'},
+                        {'name': 'downloads', 'type': 'int'}
+                    ]
+                }
+            }]
+        }
+        params = {
+            'package': 'organization/mypackage'
+        }
+
+        # latest is in returned data
+        def latest_entries_res():
+            yield {
+                    'date': dateutil.parser.parse('2017-04-19').date(),
+                    'downloads': 2,
+                    'package': 'mypackage',
+                    'source': 'packagist'
+                }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_packagist_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = \
+            mock_processor_test(processor_path, (params, datapackage,
+                                                 iter([latest_entries_res()])))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        # Asserts for the datapackage
+        dp_resources = spew_dp['resources']
+        assert len(dp_resources) == 2
+        assert dp_resources[1]['name'] == 'organization-mypackage'
+        field_names = \
+            [field['name'] for field in dp_resources[1]['schema']['fields']]
+        assert field_names == ['package', 'source', 'date', 'downloads']
+
+        # Asserts for the res_iter
+        spew_res_iter_contents = list(spew_res_iter)
+        assert len(spew_res_iter_contents) == 2
+        rows = list(spew_res_iter_contents[1])
+        assert len(rows) == 3  # updated only 3 recent rows
+        assert rows[0] == \
+            {
+                'package': 'mypackage',
+                'source': 'packagist',
+                'downloads': 3,  # value updated from api
+                'date': dateutil.parser.parse('2017-04-19').date()
+            }
+        assert rows[2] == \
+            {
+                'package': 'mypackage',
+                'source': 'packagist',
+                'downloads': 5,
+                'date': dateutil.parser.parse('2017-04-21').date()
+            }
+
+    @requests_mock.Mocker()
+    def test_add_packagist_resource_not_json(self, mock_request):
+        # Mock API responses
+        mock_request.get('https://packagist.org/packages/organization/mypackage/stats/all.json',  # noqa
+                         text="This is not json.")
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []  # nothing here
+        }
+        params = {
+            'package': 'organization/mypackage'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_packagist_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, iter([])))
+
+        # Trigger the processor with our mock `ingest` will return an exception
+        with self.assertRaises(simplejson.scanner.JSONDecodeError):
+            spew_res_iter = spew_args[1]
+            # attempt access to spew_res_iter raises exception
+            list(spew_res_iter)
+
+    @requests_mock.Mocker()
+    def test_add_packagist_resource_bad_status(self, mock_request):
+        # Mock API responses
+        error_msg = 'Hi, there was a problem with your request.'
+        mock_request.get('https://packagist.org/packages/organization/mypackage/stats/all.json',  # noqa
+                         text=error_msg, status_code=401)
+
+        # input arguments used by our mock `ingest`
+        datapackage = {
+            'name': 'my-datapackage',
+            'project': 'my-project',
+            'resources': []  # nothing here
+        }
+        params = {
+            'package': 'organization/mypackage'
+        }
+
+        # Path to the processor we want to test
+        processor_dir = \
+            os.path.dirname(datapackage_pipelines_measure.processors.__file__)
+        processor_path = os.path.join(processor_dir,
+                                      'add_packagist_resource.py')
+
+        # Trigger the processor with our mock `ingest` and capture what it will
+        # returned to `spew`.
+        spew_args, _ = mock_processor_test(processor_path,
+                                           (params, datapackage, iter([])))
+
+        # Trigger the processor with our mock `ingest` will return an exception
+        with self.assertRaises(Exception) as cm:
+            spew_res_iter = spew_args[1]
+            # attempt access to spew_res_iter raises exception
+            list(spew_res_iter)
+        self.assertEqual(str(cm.exception), error_msg)


### PR DESCRIPTION
This pull request fixes #39.

* [x] I've added tests to cover the proposed changes

This processor collects download data from packagist.org for given packages. Download data is returned from the API for all days. The processor checks the most recent entry date and makes new rows for days up to that date.